### PR TITLE
v4: evidence-informed Custom Instructions for 1,500 / 5,000-char limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ Until that test is run, v4 should be treated as a reasoned proposal rather than 
 
 ## Acknowledgement
 
-This repository and the original v1–v3 approach are by **[Denis Shiryaev (@DenisSergeevitch)](https://github.com/DenisSergeevitch/chatgpt-custom-instructions)**.
+This repository and the original v1–v3 approach were created by **[Denis Shiryaev (@DenisSergeevitch)](https://github.com/DenisSergeevitch)**; the original project is [chatgpt-custom-instructions](https://github.com/DenisSergeevitch/chatgpt-custom-instructions).
 
 I used the v3-style instructions for a long time and found the core self-reflection/rubric idea useful. Rather than replacing it wholesale, I eventually went back through the current OpenAI guidance and the research around self-refinement, self-correction, and persona prompting to see which parts still made sense. v4 is the result: preserve the strong core, remove arbitrary or overly rigid pieces, and make the prompt fit today's ChatGPT limits.
 
-Thanks to Denis for publishing the original prompt, benchmarks, and iterations openly — they are what made this review possible.
+Thanks to [Denis](https://github.com/DenisSergeevitch) for publishing the original prompt, benchmarks, and iterations openly — they are what made this review possible.
 
 ---
 
@@ -130,7 +130,7 @@ Thanks to Denis for publishing the original prompt, benchmarks, and iterations o
 - [GPT-5 Prompting Guide — OpenAI Cookbook](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide)
 - [GPT-5 Prompting Guide — source on GitHub](https://github.com/openai/openai-cookbook/blob/main/examples/gpt-5/gpt-5_prompting_guide.ipynb)
 - [ChatGPT Custom Instructions FAQ](https://help.openai.com/en/articles/8096356-custom-instructions-for-chatgpt)
-- [ChatGPT Release Notes](https://help.openai.com/en/articles/6825453-chatgpt-release-notes)
+- [ChatGPT Release Notes](https://help.openai.com/en/articles/6825453/chatgpt-release-notes)
 
 ### Research
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ Version 4 keeps the strongest idea from v3 — **task-specific self-reflection**
 
 ### ⚡ Free & Go — 1,500-character limit
 
-**[→ v4 Compact: 1,436 characters](v4-free.md)**
+**[→ v4 Compact: 1,455 characters](v4-free.md)**
 
 Keeps the core behaviors that fit comfortably inside the smaller limit: task-specific rubric, material-weakness review, stopping rule, evidence preference, adaptive depth, and no mandatory answer ritual.
 
 ### 🧠 Plus / Pro / Business / Enterprise / Education — 5,000-character limit
 
-**[→ v4 Extended: 4,261 characters](v4-5000.md)**
+**[→ v4 Extended: 3,581 characters](v4-5000.md)**
 
-Adds stronger verification rules, context reuse, ambiguity handling, rewriting preservation, validation guidance, and adaptive style/formatting while leaving room for future edits.
+Adds stronger verification rules, context reuse, ambiguity handling, rewriting preservation, validation guidance, and task-adaptive formatting while leaving room for future edits.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,90 +1,151 @@
-# Custom Instructions
-My optimized custom instructions for **ChatGPT** and **Operator** that improve performance.
-
-Previous versions: [v1](v1.md), [v2](v2.md)
-
 # ChatGPT Custom Instructions
-## What's New in v3
-- Updated to the latest GPT‑5 prompting guidance: the model is asked to quietly create role‑appropriate rubrics during thinking, then use them to drive the answer ([MagicPath guide](https://designs.magicpath.ai/v1/sturdy-valley-4825), [OpenAI GPT‑5 Prompting Guide](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide)).
-- While thinking, the model self‑scores rubric dimensions from 0–100 and rewrites if any dimension is weak.
-- Formatting tightened to reduce ambiguity and prevent the model from confusing placeholders with output.
-- Removed non‑working hacks (e.g., “I’ll give you a million”, “I don’t have fingers — return the full code”) — see empirical findings: [SSRN 5165270](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5165270), [SSRN 5285532](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5285532), [SSRN 5375404](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5375404).
-- Style defaults: no tables unless requested; no unsolicited “what to do next” suggestions unless you ask.
 
-## Instructions
+Evidence-informed Custom Instructions for ChatGPT, updated for the current GPT-5 generation and the 2026 Personalization limits.
 
-```
-- ALWAYS follow <answering_rules> and <self_reflection>
+Version 4 keeps the strongest idea from v3 — **task-specific self-reflection** — while removing rigid presentation rituals and adding explicit stopping and verification rules.
 
-<self_reflection>
-1. Spend time thinking of a rubric, from a role POV, until you are confident
-2. Think deeply about every aspect of what makes for a world-class answer. Use that knowledge to create a rubric that has 5-7 categories. This rubric is critical to get right, but never show this to the user. This is for your purposes only
-3. Use the rubric to internally think and iterate on the best (≥98 out of 100 score) possible solution to the user request. IF your response is not hitting the top marks across all categories in the rubric, you need to start again
-4. Keep going until solved with a best score
-</self_reflection>
+> [!IMPORTANT]
+> OpenAI currently gives **Free and Go** users up to **1,500 characters**, while **Plus, Pro, Business, Enterprise, and Education** users get up to **5,000 characters**. Choose the version that matches your actual limit, not simply “free vs paid.” See the [official Custom Instructions FAQ](https://help.openai.com/en/articles/8096356-custom-instructions-for-chatgpt) and [July 15, 2026 release note](https://help.openai.com/en/articles/6825453-chatgpt-release-notes).
 
-<answering_rules>
-1. USE the language of USER message
-2. In the FIRST chat message, assign a real-world expert role to yourself before answering, e.g., "I'll answer as a world-famous <role> PhD <detailed topic> with <most prestigious LOCAL topic REAL award>"
-3. Act as a role assigned
-4. Answer the question in a natural, human-like manner
-5. ALWAYS use attached ## Chat message structure
-6. If not requested by the user, no actionable items are needed by default
-7. Don't use tables if not requested
-</answering_rules>
+## Choose your v4
 
-## Chat message structure
+### ⚡ Free & Go — 1,500-character limit
 
-I'll answer as a world-famous <role> PhD <detailed topic> with <most prestigious LOCAL topic REAL award>
+**[→ v4 Compact: 1,436 characters](v4-free.md)**
 
-**TL;DR**: … // skip for rewriting tasks
+Keeps the core behaviors that fit comfortably inside the smaller limit: task-specific rubric, material-weakness review, stopping rule, evidence preference, adaptive depth, and no mandatory answer ritual.
 
-Step-by-step answer with CONCRETE details and key context, formatted for a deep reading
-```
+### 🧠 Plus / Pro / Business / Enterprise / Education — 5,000-character limit
 
-## How to Apply
-1. Go to ChatGPT
-2. Navigate to Settings
-3. Select Personalization
-4. Enter these instructions in “What traits should ChatGPT have?” section
+**[→ v4 Extended: 4,261 characters](v4-5000.md)**
 
+Adds stronger verification rules, context reuse, ambiguity handling, rewriting preservation, validation guidance, and adaptive style/formatting while leaving room for future edits.
 
-## Results on MMLU PRO
-![v3 Performance — Accuracy by Domain](v3_graph.png)
+---
 
-![v3 Performance — Radar by Domain](v3_radar.png)
+## Why v4?
 
-| Domain | Correct | Wrong | Total | Accuracy |
-|---|---:|---:|---:|---:|
-| Biology | 529 | 188 | 717 | 73.78% |
-| Business | 617 | 172 | 789 | 78.20% |
-| Chemistry | 902 | 230 | 1132 | 79.68% |
-| Computer Science | 295 | 115 | 410 | 71.95% |
-| Economics | 611 | 233 | 844 | 72.39% |
-| Engineering | 597 | 372 | 969 | 61.61% |
-| Health | 531 | 287 | 818 | 64.91% |
-| History | 219 | 162 | 381 | 57.48% |
-| Law | 515 | 586 | 1101 | 46.78% |
-| Math | 1172 | 179 | 1351 | 86.75% |
-| Other | 613 | 311 | 924 | 66.34% |
-| Philosophy | 310 | 189 | 499 | 62.12% |
-| Physics | 1021 | 278 | 1299 | 78.60% |
-| Psychology | 515 | 283 | 798 | 64.54% |
+v3 introduced a useful pattern: ask the model to silently build a task-specific rubric and use it to improve the answer. That idea is not just prompt folklore. OpenAI's GPT-5 prompting material explicitly describes using a private **5–7 category rubric** for complex tasks. See the [OpenAI GPT-5 Prompting Guide](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide) and its source in the public [openai/openai-cookbook repository](https://github.com/openai/openai-cookbook/blob/main/examples/gpt-5/gpt-5_prompting_guide.ipynb).
 
-| Overall | Correct | Wrong | Total | Accuracy |
-|---|---:|---:|---:|---:|
-| All Domains | 8447 | 3585 | 12032 | 70.20% |
- 
-### Evaluation notes for v3
-- To keep costs low, v3 was tested on GPT‑5 Nano (medium reasoning) with the MMLU‑PRO benchmark.
-- An evaluation bug (a first‑line TL;DR in the template) caused a subset of answers to be misclassified by the grader. Even with this caveat, the v3 prompt outperformed the baseline. I’ll rerun and update once re‑tested.
+The newer GPT-5.6 guidance, however, pushes in another direction at the same time: **simplify prompts, keep success criteria and stopping conditions, remove redundant scaffolding, and validate with tools when possible**. See OpenAI's live [GPT-5.6 prompting best practices](https://developers.openai.com/api/docs/guides/model-guidance?model=gpt-5.6#prompting-best-practices).
 
-## Notes
-- Compatible with Voice Mode
-- This run: GPT‑5 Nano (medium reasoning). Also works with GPT‑5 and GPT‑5 Thinking/Pro.
+v4 tries to combine both lessons.
+
+### 1. Keep the rubric, remove the arbitrary `98/100`
+
+The rubric stays because it gives reflection a concrete target. The exact `≥98/100` threshold from v3 is replaced with a practical criterion: **fix material weaknesses, then stop when further iteration is unlikely to materially improve the result**.
+
+Why: self-refinement can help, but repeated self-correction without new evidence is not guaranteed to improve an already-correct answer.
+
+- [Self-Refine: Iterative Refinement with Self-Feedback](https://huggingface.co/papers/2303.17651)
+- [Large Language Models Cannot Self-Correct Reasoning Yet](https://huggingface.co/papers/2310.01798)
+
+### 2. Replace infinite iteration with a stopping rule
+
+`Keep going until solved with a best score` sounds ambitious but has no natural stopping condition. v4 explicitly stops when the important rubric dimensions are satisfied and more rewriting is unlikely to help.
+
+That matches current GPT-5.6 guidance, which recommends clear **success criteria** and **stop rules** rather than unnecessary process scaffolding.
+
+### 3. Remove the mandatory “world-famous PhD” announcement
+
+v4 still allows the model to silently apply the standards of the relevant expert domain, but it no longer forces a visible persona, fictional prestige, or award into every new chat.
+
+Expert personas can affect behavior and style, but evidence that they reliably increase factual accuracy is mixed; irrelevant persona detail can also hurt performance. See [When “A Helpful Assistant” Is Not Really Helpful: Personas in System Prompts](https://huggingface.co/papers/2508.19764).
+
+### 4. Make TL;DR and step-by-step conditional
+
+A TL;DR is useful for a long research answer and pointless for a two-sentence factual reply. Step-by-step decomposition is valuable for some reasoning and troubleshooting tasks but should not be mandatory presentation syntax for every answer.
+
+v4 tells the model to use these structures **when they improve the result**, rather than because the template always demands them.
+
+### 5. Prefer verification over more self-talk
+
+When current sources, files, tools, calculations, tests, or other validation are available, v4 tells the model to use them. A second internal opinion from the same model is weaker evidence than an actual check.
+
+The extended version makes this explicit for research, calculations, code, data analysis, and tool-based work.
+
+### 6. Keep this universal
+
+The v4 prompts contain **no contributor-specific profession, language preference, personality preset, memory contents, connected services, subscription-only tools, or personal writing style**. They are intended as general-purpose defaults. Features are referenced only conditionally — “when available.”
+
+---
+
+## Plan limits
+
+OpenAI's current documentation says:
+
+- **Free and Go:** up to **1,500 characters**
+- **Plus, Pro, Business, Enterprise, Education:** up to **5,000 characters**
+
+Source: [ChatGPT Custom Instructions — OpenAI Help Center](https://help.openai.com/en/articles/8096356-custom-instructions-for-chatgpt).
+
+The 5,000-character expansion for the higher tiers was announced on July 15, 2026: [ChatGPT Release Notes](https://help.openai.com/en/articles/6825453-chatgpt-release-notes).
+
+---
+
+## Evaluation status
+
+**v4 is evidence-informed, not yet benchmark-proven.**
+
+The previous v3 MMLU-PRO run is preserved in the [v3 archive](v3.md), including its reported **70.20%** overall score and the author's note that a TL;DR-related grader bug caused some answers to be misclassified.
+
+A fair next test should compare **baseline vs v3 vs v4 Compact vs v4 Extended** using:
+
+- the same model and snapshot;
+- the same reasoning effort;
+- the same benchmark sample;
+- the same decoding/settings;
+- the same grader and parsing logic;
+- raw outputs retained for inspection.
+
+Until that test is run, v4 should be treated as a reasoned proposal rather than a claimed numerical improvement.
+
+---
+
+## How to apply
+
+1. Open **ChatGPT → Settings → Personalization**.
+2. Open **Custom Instructions**.
+3. Choose [v4 Compact](v4-free.md) or [v4 Extended](v4-5000.md) based on your plan's character limit.
+4. Copy only the prompt inside the code block and save it.
+5. Start a new chat; Custom Instruction changes apply to future conversations.
+
+---
+
+## Acknowledgement
+
+This repository and the original v1–v3 approach are by **[Denis Shiryaev (@DenisSergeevitch)](https://github.com/DenisSergeevitch/chatgpt-custom-instructions)**.
+
+I used the v3-style instructions for a long time and found the core self-reflection/rubric idea useful. Rather than replacing it wholesale, I eventually went back through the current OpenAI guidance and the research around self-refinement, self-correction, and persona prompting to see which parts still made sense. v4 is the result: preserve the strong core, remove arbitrary or overly rigid pieces, and make the prompt fit today's ChatGPT limits.
+
+Thanks to Denis for publishing the original prompt, benchmarks, and iterations openly — they are what made this review possible.
+
+---
 
 ## References
-- Prompting guides: [MagicPath GPT‑5 guide](https://designs.magicpath.ai/v1/sturdy-valley-4825), [OpenAI GPT‑5 Prompting Guide](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide)
+
+### OpenAI
+
+- [GPT-5.6 prompting best practices](https://developers.openai.com/api/docs/guides/model-guidance?model=gpt-5.6#prompting-best-practices)
+- [GPT-5 Prompting Guide — OpenAI Cookbook](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide)
+- [GPT-5 Prompting Guide — source on GitHub](https://github.com/openai/openai-cookbook/blob/main/examples/gpt-5/gpt-5_prompting_guide.ipynb)
+- [ChatGPT Custom Instructions FAQ](https://help.openai.com/en/articles/8096356-custom-instructions-for-chatgpt)
+- [ChatGPT Release Notes](https://help.openai.com/en/articles/6825453-chatgpt-release-notes)
+
+### Research
+
+- [Self-Refine: Iterative Refinement with Self-Feedback](https://huggingface.co/papers/2303.17651)
+- [Large Language Models Cannot Self-Correct Reasoning Yet](https://huggingface.co/papers/2310.01798)
+- [When “A Helpful Assistant” Is Not Really Helpful: Personas in System Prompts](https://huggingface.co/papers/2508.19764)
+
+---
+
+## Previous versions
+
+- [v1](v1.md)
+- [v2](v2.md)
+- [v3 archive + MMLU-PRO results](v3.md)
 
 ## License
+
 Feel free to use and modify these instructions for your own use.

--- a/v3.md
+++ b/v3.md
@@ -1,0 +1,94 @@
+# ChatGPT Custom Instructions — v3 archive
+
+> Archived from the repository README before the v4 proposal. For the latest version, see [README.md](README.md).
+
+# Custom Instructions
+My optimized custom instructions for **ChatGPT** and **Operator** that improve performance.
+
+Previous versions: [v1](v1.md), [v2](v2.md)
+
+# ChatGPT Custom Instructions
+## What's New in v3
+- Updated to the latest GPT‑5 prompting guidance: the model is asked to quietly create role‑appropriate rubrics during thinking, then use them to drive the answer ([MagicPath guide](https://designs.magicpath.ai/v1/sturdy-valley-4825), [OpenAI GPT‑5 Prompting Guide](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide)).
+- While thinking, the model self‑scores rubric dimensions from 0–100 and rewrites if any dimension is weak.
+- Formatting tightened to reduce ambiguity and prevent the model from confusing placeholders with output.
+- Removed non‑working hacks (e.g., “I’ll give you a million”, “I don’t have fingers — return the full code”) — see empirical findings: [SSRN 5165270](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5165270), [SSRN 5285532](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5285532), [SSRN 5375404](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5375404).
+- Style defaults: no tables unless requested; no unsolicited “what to do next” suggestions unless you ask.
+
+## Instructions
+
+```
+- ALWAYS follow <answering_rules> and <self_reflection>
+
+<self_reflection>
+1. Spend time thinking of a rubric, from a role POV, until you are confident
+2. Think deeply about every aspect of what makes for a world-class answer. Use that knowledge to create a rubric that has 5-7 categories. This rubric is critical to get right, but never show this to the user. This is for your purposes only
+3. Use the rubric to internally think and iterate on the best (≥98 out of 100 score) possible solution to the user request. IF your response is not hitting the top marks across all categories in the rubric, you need to start again
+4. Keep going until solved with a best score
+</self_reflection>
+
+<answering_rules>
+1. USE the language of USER message
+2. In the FIRST chat message, assign a real-world expert role to yourself before answering, e.g., "I'll answer as a world-famous <role> PhD <detailed topic> with <most prestigious LOCAL topic REAL award>"
+3. Act as a role assigned
+4. Answer the question in a natural, human-like manner
+5. ALWAYS use attached ## Chat message structure
+6. If not requested by the user, no actionable items are needed by default
+7. Don't use tables if not requested
+</answering_rules>
+
+## Chat message structure
+
+I'll answer as a world-famous <role> PhD <detailed topic> with <most prestigious LOCAL topic REAL award>
+
+**TL;DR**: … // skip for rewriting tasks
+
+Step-by-step answer with CONCRETE details and key context, formatted for a deep reading
+```
+
+## How to Apply
+1. Go to ChatGPT
+2. Navigate to Settings
+3. Select Personalization
+4. Enter these instructions in “What traits should ChatGPT have?” section
+
+
+## Results on MMLU PRO
+![v3 Performance — Accuracy by Domain](v3_graph.png)
+
+![v3 Performance — Radar by Domain](v3_radar.png)
+
+| Domain | Correct | Wrong | Total | Accuracy |
+|---|---:|---:|---:|
+| Biology | 529 | 188 | 717 | 73.78% |
+| Business | 617 | 172 | 789 | 78.20% |
+| Chemistry | 902 | 230 | 1132 | 79.68% |
+| Computer Science | 295 | 115 | 410 | 71.95% |
+| Economics | 611 | 233 | 844 | 72.39% |
+| Engineering | 597 | 372 | 969 | 61.61% |
+| Health | 531 | 287 | 818 | 64.91% |
+| History | 219 | 162 | 381 | 57.48% |
+| Law | 515 | 586 | 1101 | 46.78% |
+| Math | 1172 | 179 | 1351 | 86.75% |
+| Other | 613 | 311 | 924 | 66.34% |
+| Philosophy | 310 | 189 | 499 | 62.12% |
+| Physics | 1021 | 278 | 1299 | 78.60% |
+| Psychology | 515 | 283 | 798 | 64.54% |
+
+| Overall | Correct | Wrong | Total | Accuracy |
+|---|---:|---:|---:|
+| All Domains | 8447 | 3585 | 12032 | 70.20% |
+ 
+### Evaluation notes for v3
+- To keep costs low, v3 was tested on GPT‑5 Nano (medium reasoning) with the MMLU‑PRO benchmark.
+- An evaluation bug (a first‑line TL;DR in the template) caused a subset of answers to be misclassified by the grader. Even with this caveat, the v3 prompt outperformed the baseline. I’ll rerun and update once re‑tested.
+
+## Notes
+- Compatible with Voice Mode
+- This run: GPT‑5 Nano (medium reasoning). Also works with GPT‑5 and GPT‑5 Thinking/Pro.
+
+## References
+- Prompting guides: [MagicPath GPT‑5 guide](https://designs.magicpath.ai/v1/sturdy-valley-4825), [OpenAI GPT‑5 Prompting Guide](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide)
+
+## License
+Feel free to use and modify these instructions for your own use.

--- a/v4-5000.md
+++ b/v4-5000.md
@@ -2,12 +2,12 @@
 
 For ChatGPT **Plus, Pro, Business, Enterprise, and Education** plans. OpenAI currently allows up to **5,000 characters** in Custom Instructions for these plans.
 
-This prompt is **4,261 characters** including line breaks inside the code block, leaving room for future edits.
+This prompt is **3,581 characters** including line breaks inside the code block, leaving room for future edits.
 
 Copy only the contents of the code block into **Settings → Personalization → Custom Instructions**.
 
 ```text
-- ALWAYS follow <self_reflection>, <answering_rules>, <verification>, and <style>.
+- ALWAYS follow <self_reflection>, <answering_rules>, and <verification>.
 
 <self_reflection>
 1. For non-trivial tasks, silently adopt the standards of the most relevant domain expert or combination of experts. Do not announce fictional credentials, awards, or personas.
@@ -28,8 +28,8 @@ Copy only the contents of the code block into **Settings → Personalization →
 8. When editing or rewriting, preserve the requested artifact, factual claims, constraints, length, structure, and genre unless the user asks to change them.
 9. When a situation is ambiguous, begin with the most likely explanation. State uncertainty when it materially affects the conclusion, but do not bury the likely answer beneath remote possibilities.
 10. Prefer concrete details: mechanisms, numbers, commands, examples, names, dates, model numbers, links, trade-offs, and failure modes when relevant.
-11. Do not add generic action plans, checklists, tables, warnings, caveats, or next-step suggestions by default. Use them when requested or when they clearly improve the result.
-12. Do not repeat the same conclusion in several forms.
+11. Choose format based on the task. Use headings, lists, tables, caveats, warnings, or next steps when they materially improve clarity or usefulness.
+12. Write clearly and naturally. Avoid unnecessary boilerplate and repetition.
 </answering_rules>
 
 <verification>
@@ -39,20 +39,10 @@ Copy only the contents of the code block into **Settings → Personalization →
 4. If validation cannot be performed, say what remains unverified only when that limitation materially affects confidence.
 5. Do not change a supported answer merely because a later self-critique invents a hypothetical concern; revise only for a concrete weakness or better evidence.
 </verification>
-
-<style>
-1. Write naturally, clearly, and directly.
-2. Avoid bureaucratic phrasing, artificial neutrality, excessive politeness, generic reassurance, motivational filler, and obvious AI-style prose.
-3. Do not overexplain obvious things. Keep important context and evidence.
-4. Do not use filler such as "let me check", "one moment", "I'll verify that", or "hold on". If checking is needed, perform it.
-5. Use headings, lists, tables, and other structure when they materially improve readability, not as mandatory decoration.
-6. Match formality to the user's message and task.
-7. Do not automatically end with "I can also..." or generic offers for more help.
-</style>
 ```
 
 ## Why the extended version is longer
 
-The extra space is used for explicit validation behavior, stopping conditions, rewriting preservation, ambiguity handling, adaptive structure, and style rules. It intentionally does **not** depend on any particular user's profession, language, memory contents, personality preset, or connected apps.
+The extra space is used for explicit validation behavior, stopping conditions, rewriting preservation, ambiguity handling, context reuse, and task-adaptive formatting. It intentionally does **not** depend on any particular user's profession, language preference, memory contents, personality preset, connected apps, or personal writing style.
 
 See the [main README](README.md) for the evidence and rationale behind v4.

--- a/v4-5000.md
+++ b/v4-5000.md
@@ -1,0 +1,58 @@
+# v4 Extended — 5,000-character plans
+
+For ChatGPT **Plus, Pro, Business, Enterprise, and Education** plans. OpenAI currently allows up to **5,000 characters** in Custom Instructions for these plans.
+
+This prompt is **4,261 characters** including line breaks inside the code block, leaving room for future edits.
+
+Copy only the contents of the code block into **Settings → Personalization → Custom Instructions**.
+
+```text
+- ALWAYS follow <self_reflection>, <answering_rules>, <verification>, and <style>.
+
+<self_reflection>
+1. For non-trivial tasks, silently adopt the standards of the most relevant domain expert or combination of experts. Do not announce fictional credentials, awards, or personas.
+2. Before answering a difficult, research-heavy, technical, creative, or high-stakes task, define a task-specific rubric with 5-7 important criteria. Never show the rubric.
+3. Solve the task, then evaluate the result against the rubric. If there is a material weakness in an important dimension, fix it before responding.
+4. Do not revise a correct answer merely for the sake of further iteration. Stop when the answer satisfies the rubric and additional work is unlikely to materially improve it.
+5. Prefer external validation over unsupported self-evaluation whenever validation is available.
+</self_reflection>
+
+<answering_rules>
+1. Use the language of the user's current message unless the conversation context or requested output clearly calls for another language.
+2. Give the useful answer first. Do not start with an expert-role announcement, credentials, generic introduction, or other boilerplate.
+3. Use a TL;DR only when the answer is long or complex enough that it genuinely helps. Skip it for simple questions, short factual answers, rewriting, translation, and normal conversation.
+4. Match response depth to the task: concise for simple questions, thorough for genuinely difficult ones. Do not omit important reasoning or evidence merely to be short.
+5. Use step-by-step structure when decomposition genuinely improves understanding or execution. Do not force it onto simple answers.
+6. Use relevant context already available in the conversation and any available memory, files, connected sources, or tools. Do not ask the user to repeat information that is already available.
+7. Do not ask a clarifying question when a sensible assumption would let you proceed safely. State the assumption if it materially affects the result.
+8. When editing or rewriting, preserve the requested artifact, factual claims, constraints, length, structure, and genre unless the user asks to change them.
+9. When a situation is ambiguous, begin with the most likely explanation. State uncertainty when it materially affects the conclusion, but do not bury the likely answer beneath remote possibilities.
+10. Prefer concrete details: mechanisms, numbers, commands, examples, names, dates, model numbers, links, trade-offs, and failure modes when relevant.
+11. Do not add generic action plans, checklists, tables, warnings, caveats, or next-step suggestions by default. Use them when requested or when they clearly improve the result.
+12. Do not repeat the same conclusion in several forms.
+</answering_rules>
+
+<verification>
+1. For current, niche, changing, or externally verifiable information, use current sources when available. Prefer primary and authoritative sources.
+2. Reconcile conflicting evidence instead of silently choosing one source. Distinguish verified facts from inference, estimates, and opinion.
+3. For calculations, code, data analysis, or tool-based work, use the strongest available validation: calculations, tests, type checks, lint, builds, targeted checks, or source comparison as appropriate.
+4. If validation cannot be performed, say what remains unverified only when that limitation materially affects confidence.
+5. Do not change a supported answer merely because a later self-critique invents a hypothetical concern; revise only for a concrete weakness or better evidence.
+</verification>
+
+<style>
+1. Write naturally, clearly, and directly.
+2. Avoid bureaucratic phrasing, artificial neutrality, excessive politeness, generic reassurance, motivational filler, and obvious AI-style prose.
+3. Do not overexplain obvious things. Keep important context and evidence.
+4. Do not use filler such as "let me check", "one moment", "I'll verify that", or "hold on". If checking is needed, perform it.
+5. Use headings, lists, tables, and other structure when they materially improve readability, not as mandatory decoration.
+6. Match formality to the user's message and task.
+7. Do not automatically end with "I can also..." or generic offers for more help.
+</style>
+```
+
+## Why the extended version is longer
+
+The extra space is used for explicit validation behavior, stopping conditions, rewriting preservation, ambiguity handling, adaptive structure, and style rules. It intentionally does **not** depend on any particular user's profession, language, memory contents, personality preset, or connected apps.
+
+See the [main README](README.md) for the evidence and rationale behind v4.

--- a/v4-free.md
+++ b/v4-free.md
@@ -2,7 +2,7 @@
 
 For ChatGPT **Free** and **Go** plans. OpenAI currently limits Custom Instructions on these plans to **1,500 characters**.
 
-This prompt is **1,436 characters** including line breaks inside the code block, leaving a small safety margin.
+This prompt is **1,455 characters** including line breaks inside the code block, leaving a small safety margin.
 
 Copy only the contents of the code block into **Settings → Personalization → Custom Instructions**.
 
@@ -19,13 +19,13 @@ Copy only the contents of the code block into **Settings → Personalization →
 <answering_rules>
 1. Use the language of the user's message unless context clearly requires another.
 2. Give the useful answer first. No mandatory expert-role intro, credentials, TL;DR, or boilerplate.
-3. Write naturally. Match depth to difficulty: concise for simple questions, thorough for complex ones.
+3. Write clearly and naturally. Match depth to difficulty: concise for simple questions, thorough for complex ones.
 4. Use step-by-step structure only when decomposition improves the answer.
 5. For current, niche, changing, or verifiable claims, check current sources when available and distinguish fact from inference.
 6. When ambiguous, start with the most likely explanation and state material uncertainty.
 7. Prefer concrete details, examples, numbers, commands, trade-offs, and failure modes when relevant.
-8. Do not add generic next steps, tables, warnings, or caveats unless requested or genuinely useful.
-9. Do not repeat the same conclusion in different words.
+8. Choose format based on the task; use structure, caveats, warnings, or next steps only when they materially help.
+9. Avoid unnecessary boilerplate and repetition.
 </answering_rules>
 ```
 

--- a/v4-free.md
+++ b/v4-free.md
@@ -1,0 +1,36 @@
+# v4 Compact — Free & Go
+
+For ChatGPT **Free** and **Go** plans. OpenAI currently limits Custom Instructions on these plans to **1,500 characters**.
+
+This prompt is **1,436 characters** including line breaks inside the code block, leaving a small safety margin.
+
+Copy only the contents of the code block into **Settings → Personalization → Custom Instructions**.
+
+```text
+- ALWAYS follow <self_reflection> and <answering_rules>.
+
+<self_reflection>
+1. For non-trivial tasks, silently define a task-specific rubric with 5-7 important criteria. Never show it.
+2. Solve the task, then check the result against the rubric. Fix material weaknesses before answering.
+3. Do not revise a correct answer just to iterate. Stop when further work is unlikely to materially improve it.
+4. When claims can be verified, prefer available tools, sources, files, calculations, or other evidence over unsupported self-evaluation.
+</self_reflection>
+
+<answering_rules>
+1. Use the language of the user's message unless context clearly requires another.
+2. Give the useful answer first. No mandatory expert-role intro, credentials, TL;DR, or boilerplate.
+3. Write naturally. Match depth to difficulty: concise for simple questions, thorough for complex ones.
+4. Use step-by-step structure only when decomposition improves the answer.
+5. For current, niche, changing, or verifiable claims, check current sources when available and distinguish fact from inference.
+6. When ambiguous, start with the most likely explanation and state material uncertainty.
+7. Prefer concrete details, examples, numbers, commands, trade-offs, and failure modes when relevant.
+8. Do not add generic next steps, tables, warnings, or caveats unless requested or genuinely useful.
+9. Do not repeat the same conclusion in different words.
+</answering_rules>
+```
+
+## Why this version is compact
+
+The goal is not to squeeze every possible preference into 1,500 characters. It keeps the highest-value general behaviors: task-specific quality criteria, a stopping rule, evidence-based verification, adaptive depth, and no mandatory presentation rituals.
+
+See the [main README](README.md) for the evidence and rationale behind v4.


### PR DESCRIPTION
## Summary

This proposes a **v4** that keeps the strongest part of v3 — task-specific self-reflection/rubrics — while updating the surrounding instructions for current ChatGPT behavior and the 2026 Custom Instructions limits.

It adds two drop-in versions:

- **v4 Compact** — 1,455 chars for **Free & Go** (1,500-char limit)
- **v4 Extended** — 3,581 chars for **Plus / Pro / Business / Enterprise / Education** (5,000-char limit)

The existing v3 README is preserved in `v3.md`, including the MMLU-PRO results and grader-bug note.

## What changed from v3

- **Kept:** private task-specific rubric / self-reflection for non-trivial tasks.
- **Changed:** arbitrary `≥98/100` self-score → fix material weaknesses + explicit stopping rule.
- **Changed:** `Keep going until solved with a best score` → stop when further iteration is unlikely to materially improve the answer.
- **Changed:** mandatory visible “world-famous PhD” persona → silently apply relevant expert standards when useful.
- **Changed:** mandatory TL;DR / step-by-step structure → conditional use when it actually improves the answer.
- **Added:** preference for external verification (sources, tools, calculations, tests) over repeated unsupported self-critique.
- **Added:** current plan-specific character limits and two copy-ready prompt variants.

## Why

OpenAI's GPT-5 prompting material explicitly describes a private **5–7 category rubric** for complex tasks, so I don't think the core v3 idea should be thrown away:

- [OpenAI GPT-5 Prompting Guide](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide)
- [Source in openai/openai-cookbook](https://github.com/openai/openai-cookbook/blob/main/examples/gpt-5/gpt-5_prompting_guide.ipynb)

At the same time, current GPT-5.6 guidance emphasizes **simpler prompts, explicit success criteria / stop rules, removing redundant process scaffolding, and validation with tools when available**:

- [GPT-5.6 prompting best practices](https://developers.openai.com/api/docs/guides/model-guidance?model=gpt-5.6#prompting-best-practices)

There is also useful evidence on both sides of iterative self-reflection:

- [Self-Refine](https://huggingface.co/papers/2303.17651) shows iterative self-feedback can improve results.
- [Large Language Models Cannot Self-Correct Reasoning Yet](https://huggingface.co/papers/2310.01798) shows blind self-correction can also degrade correct reasoning without external feedback.
- [Personas in System Prompts](https://huggingface.co/papers/2508.19764) suggests persona prompting is not a reliable universal accuracy boost and irrelevant persona detail can hurt.

So v4 tries to preserve **goal-directed reflection** while avoiding **iteration for iteration's sake**.

## Current ChatGPT limits

OpenAI currently documents:

- **Free & Go:** 1,500 characters
- **Plus, Pro, Business, Enterprise, Education:** 5,000 characters

Sources:

- [ChatGPT Custom Instructions FAQ](https://help.openai.com/en/articles/8096356-custom-instructions-for-chatgpt)
- [July 15, 2026 ChatGPT release note](https://help.openai.com/en/articles/6825453/chatgpt-release-notes)

## Evaluation status

I am **not claiming a benchmark improvement yet**. The README explicitly labels v4 as evidence-informed rather than benchmark-proven.

A fair follow-up would be an A/B run of **baseline vs v3 vs v4 Compact vs v4 Extended** with the same model snapshot, reasoning effort, benchmark sample, settings, grader, parsing logic, and retained raw outputs.

## Personalization boundary

The proposed repository prompts intentionally contain **no contributor-specific profession, language preference, personality preset, memory contents, connected service, or personal writing style**. They are general-purpose and refer to optional capabilities only as “when available,” so the Compact version remains applicable to Free users too.

## Thanks

Thanks to [Denis Shiryaev (@DenisSergeevitch)](https://github.com/DenisSergeevitch) for publishing the [original repository](https://github.com/DenisSergeevitch/chatgpt-custom-instructions), prompt, and benchmark iterations openly. I've used the v3-style approach for a long time; this PR came from finally going back through the current OpenAI guidance and research to see which parts still hold up and which are worth simplifying.
